### PR TITLE
Refactor:Added possibility to use view as an image

### DIFF
--- a/Sources/OnboardingKit/Logic structures/OnboardingSlide.swift
+++ b/Sources/OnboardingKit/Logic structures/OnboardingSlide.swift
@@ -6,22 +6,70 @@
 // 
 
 // MARK: OnboardingSlide structure
+import SwiftUI
 
 /// Representing an onboarding slide, which include:
 /// Title of the whole slide, Subtitle of App's feature, Description of App's feature, Image name for  App's feature
-
-public struct OnboardingSlide: Hashable{
+public struct OnboardingSlide: Hashable {
     // MARK: Properties
     public let slideTitle: String
     public let subtitle: String
     public let subtitleDescription: String
-    public let imageName: String
     
-    // MARK: Initializer
-    public init(slideTitle: String, subtitle: String, subtitleDescription: String, imageName: String) {
+    public let imageName: String?
+    
+    public let customView: AnyView?
+    
+    public let imageAlignment: Alignment
+    public let imageContentMode: ContentMode
+    
+    // MARK: Initializers
+    public init(
+        slideTitle: String,
+        subtitle: String,
+        subtitleDescription: String,
+        imageName: String,
+        imageAlignment: Alignment = .center,
+        imageContentMode: ContentMode = .fit
+    ) {
         self.slideTitle = slideTitle
         self.subtitle = subtitle
         self.subtitleDescription = subtitleDescription
         self.imageName = imageName
+        self.customView = nil
+        self.imageAlignment = imageAlignment
+        self.imageContentMode = imageContentMode
+    }
+    
+    public init(
+        slideTitle: String,
+        subtitle: String,
+        subtitleDescription: String,
+        customView: AnyView,
+        imageAlignment: Alignment = .center,
+        imageContentMode: ContentMode = .fit
+    ) {
+        self.slideTitle = slideTitle
+        self.subtitle = subtitle
+        self.subtitleDescription = subtitleDescription
+        self.imageName = nil
+        self.customView = customView
+        self.imageAlignment = imageAlignment
+        self.imageContentMode = imageContentMode
+    }
+    
+    // MARK: Hashable Conformance
+    public func hash(into hasher: inout Hasher) {
+            hasher.combine(slideTitle)
+            hasher.combine(subtitle)
+            hasher.combine(subtitleDescription)
+            hasher.combine(imageName)
+        }
+    
+    public static func == (lhs: OnboardingSlide, rhs: OnboardingSlide) -> Bool {
+        return lhs.slideTitle == rhs.slideTitle &&
+               lhs.subtitle == rhs.subtitle &&
+               lhs.subtitleDescription == rhs.subtitleDescription &&
+               lhs.imageName == rhs.imageName
     }
 }

--- a/Sources/OnboardingKit/UI/OnboardingCustomView.swift
+++ b/Sources/OnboardingKit/UI/OnboardingCustomView.swift
@@ -86,14 +86,30 @@ public struct OnboardingCustomView: View{
                     }
                    
                     // MARK: - Image Section
-                    /// Displays current step's image, fills the frame and clips overflow
+                    /// Displays current step's image, or view as an image, fills the frame and clips overflow
                     // TODO: - Update image with actual image
-                    Image(viewModel.state.currentStep.imageName)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width:geometry.size.width, height: geometry.size.height*sizeUIConfiguration.imageHeight)
-                        .clipped()
-                        .padding(.top, sizeUIConfiguration.imageTopPadding)
+                    if let customView = viewModel.state.currentStep.customView {
+                        customView
+                            .aspectRatio(contentMode: viewModel.state.currentStep.imageContentMode)
+                            .frame(
+                                width: geometry.size.width,
+                                height: geometry.size.height * sizeUIConfiguration.imageHeight,
+                                alignment: viewModel.state.currentStep.imageAlignment
+                            )
+                            .clipped()
+                            .padding(.top, sizeUIConfiguration.imageTopPadding)
+                    } else if let imageName = viewModel.state.currentStep.imageName {
+                        Image(imageName)
+                            .resizable()
+                            .aspectRatio(contentMode: viewModel.state.currentStep.imageContentMode)
+                            .frame(
+                                width: geometry.size.width,
+                                height: geometry.size.height * sizeUIConfiguration.imageHeight,
+                                alignment: viewModel.state.currentStep.imageAlignment
+                            )
+                            .clipped()
+                            .padding(.top, sizeUIConfiguration.imageTopPadding)
+                    }
                     
                     /// Spacer ability
                     Spacer()


### PR DESCRIPTION
Summary:

This changes give opportunity to use the custom view as an image as slide images.
Also makes possible to give custom positioning for every image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding slides now support displaying either an image or a custom SwiftUI view for more flexible content presentation.
  * Added options to control the alignment and content mode of images or custom views within onboarding slides.

* **Enhancements**
  * Improved layout customization for onboarding content, allowing richer and more adaptable onboarding experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->