### PR TITLE
Revert commit for 3819079

### DIFF
--- a/Sources/OnboardingKit/UI/Styles/ButtonStyles/PrimaryButtonStyle.swift
+++ b/Sources/OnboardingKit/UI/Styles/ButtonStyles/PrimaryButtonStyle.swift
@@ -48,7 +48,7 @@ public struct PrimaryButtonStyle: ButtonStyle {
         horizontalPadding: CGFloat = 0,
         cornerRadius: CGFloat = 22,
         pressedOpacity: Double = 0.8,
-        buttonHeight: CGFloat = 200
+        buttonHeight: CGFloat = 45
     ) {
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
@@ -63,8 +63,7 @@ public struct PrimaryButtonStyle: ButtonStyle {
     /// Builds the button's body.
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(maxWidth: .infinity)
-            .frame(height: buttonHeight)
+            .frame(maxWidth: .infinity, maxHeight: buttonHeight)
             .padding(.vertical, verticalPadding)
             .background(backgroundColor)
             .foregroundColor(foregroundColor)

--- a/Sources/OnboardingKit/UI/Styles/ButtonStyles/SecondaryButtonStyle.swift
+++ b/Sources/OnboardingKit/UI/Styles/ButtonStyles/SecondaryButtonStyle.swift
@@ -41,7 +41,7 @@ public struct SecondaryButtonStyle: ButtonStyle {
         verticalPadding: CGFloat = 7,
         horizontalPadding: CGFloat = 0,
         pressedOpacity: Double = 0.8,
-        buttonHeight: CGFloat = 200
+        buttonHeight: CGFloat = 45
     ) {
         self.backgroundMaterial = backgroundMaterial
         self.verticalPadding = verticalPadding
@@ -53,8 +53,7 @@ public struct SecondaryButtonStyle: ButtonStyle {
     /// Builds the button's body.
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(maxWidth: .infinity)
-            .frame(height: buttonHeight)
+            .frame(maxWidth: .infinity, maxHeight: buttonHeight)
             .padding(.vertical, verticalPadding)
             .background(backgroundMaterial)
             .clipShape(Capsule())


### PR DESCRIPTION
@GeorgeKyrylenko1998 this is revert commit for the commit 3819079. I did this to don't delete commit 3819079 made by mistake.
Also, fixed size for the next button on the OnboardingScreen 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Primary and Secondary buttons now default to a compact height (45) for a cleaner, more consistent look.
  * Buttons remain full‑width and now use a maximum height constraint instead of a fixed height, improving adaptability to dynamic text and accessibility settings.
  * Reduces excessive vertical spacing and ensures a more uniform appearance across screens, especially in onboarding flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->